### PR TITLE
Added CODEOWNERS file containing developers team to repo

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+* @sportmap-estonia/developers


### PR DESCRIPTION
Added CODEOWNERS file with the newly created developers team, it currently shows an error since the developers team needs to have write access to the repo, however for some reason I am unable to change it from read (probably lack of organization level permissions)

This file is necessary for automatic reviewer assignment of all team members to all PRs within this repo.