### PR TITLE
25 add login page to frontend

### DIFF
--- a/frontend/src/app/(app)/layout.tsx
+++ b/frontend/src/app/(app)/layout.tsx
@@ -1,0 +1,21 @@
+import ResponsiveNav from "@/components/navigation/ResponsiveNav";
+
+export default function ApplicationLayout({
+  children,
+}: Readonly<{
+  children: React.ReactNode;
+}>) {
+  return (
+    <>
+      {/* Responsive Navigation (fixed position) */}
+      <ResponsiveNav />
+        
+      {/* Main Content Area */}
+      {/* Mobile: full height minus bottom nav (80px = h-20) */}
+      {/* Desktop: full height with left margin for sidebar */}
+      <main className="h-[calc(100vh-5rem)] md:h-screen md:ml-16">
+        {children}
+      </main>
+    </>
+  );
+}

--- a/frontend/src/app/(app)/map/page.tsx
+++ b/frontend/src/app/(app)/map/page.tsx
@@ -1,0 +1,9 @@
+import MapView from "@/components/MapView";
+
+export default function MapPage() {
+  return (
+    <div className="h-full w-full bg-zinc-50 font-sans dark:bg-black">
+      <MapView />
+    </div>
+  );
+}

--- a/frontend/src/app/(auth)/login/page.tsx
+++ b/frontend/src/app/(auth)/login/page.tsx
@@ -1,0 +1,67 @@
+"use client"
+
+import { motion } from "framer-motion";
+import { Activity, ArrowRight, MapPin } from "lucide-react";
+import { useRouter } from "next/navigation";
+
+export default function LoginPage() {
+    const router = useRouter();
+    const publicApiUrl = process.env.NEXT_PUBLIC_API_URL || "https://localhost:7485";
+
+    const handleLogin = () => {
+        window.location.href = `${publicApiUrl}/api/auth/login/google`;
+    }
+
+    const handleGuest = () => {
+        router.push("/map");
+    }
+
+    return (
+      <div className="relative w-full h-screen bg-[#0a0a0f] flex flex-col items-center justify-center p-8 overflow-hidden">
+      <div className="absolute top-[-20%] left-[-20%] w-[140%] h-[140%] bg-[radial-gradient(circle_at_center,_var(--tw-gradient-stops))] from-blue-900/20 via-[#0a0a0f] to-[#0a0a0f] z-0" />
+      <div className="absolute top-20 right-10 w-32 h-32 bg-cyan-500/10 rounded-full blur-3xl animate-pulse" />
+      <div className="absolute bottom-20 left-10 w-40 h-40 bg-blue-600/10 rounded-full blur-3xl animate-pulse delay-700" />
+
+      <motion.div
+        initial={{
+          opacity: 0,
+          y: 20,
+        }}
+        animate={{
+          opacity: 1,
+          y: 0,
+        }}
+        transition={{
+          duration: 0.8,
+        }}
+        className="relative z-10 flex flex-col items-center w-full max-w-sm"
+      >
+        <div className="w-20 h-20 bg-gradient-to-tr from-blue-600 to-cyan-500 rounded-2xl flex items-center justify-center shadow-[0_0_30px_rgba(59,130,246,0.5)] mb-6 rotate-3">
+          <MapPin className="text-white w-10 h-10 absolute -ml-2 -mt-2" />
+          <Activity className="text-white/80 w-8 h-8 absolute ml-2 mt-2" />
+        </div>
+        <h1 className="text-4xl font-bold text-white mb-2 tracking-tight">
+          SportMap
+        </h1>
+        <p className="text-gray-400 text-center mb-10 text-lg">
+          Discover sports places. <br /> Share your journey.
+        </p>
+        <button
+          onClick={handleLogin}
+          className="w-full py-4 rounded-xl bg-gradient-to-r from-blue-600 to-cyan-500 text-white font-bold text-lg shadow-[0_0_20px_rgba(59,130,246,0.4)] hover:shadow-[0_0_30px_rgba(59,130,246,0.6)] transition-all active:scale-[0.98] flex items-center justify-center group"
+        >
+          Sign In With Google
+          <ArrowRight className="ml-2 w-5 h-5 group-hover:translate-x-1 transition-transform" />
+        </button>
+        <div className="mt-6 flex flex-col items-center space-y-4">
+          <button
+            onClick={handleGuest}
+            className="text-gray-500 text-xs hover:text-gray-400 transition-colors"
+          >
+            Continue as Guest
+          </button>
+        </div>
+      </motion.div>
+    </div>
+  )
+}

--- a/frontend/src/app/layout.tsx
+++ b/frontend/src/app/layout.tsx
@@ -1,6 +1,5 @@
 import type { Metadata } from "next";
 import "./globals.css";
-import ResponsiveNav from "@/components/navigation/ResponsiveNav";
 
 export const metadata: Metadata = {
   title: "SportMap",
@@ -15,15 +14,7 @@ export default function RootLayout({
   return (
     <html lang="en">
       <body className="antialiased">
-        {/* Responsive Navigation (fixed position) */}
-        <ResponsiveNav />
-        
-        {/* Main Content Area */}
-        {/* Mobile: full height minus bottom nav (80px = h-20) */}
-        {/* Desktop: full height with left margin for sidebar */}
-        <main className="h-[calc(100vh-5rem)] md:h-screen md:ml-16">
-          {children}
-        </main>
+        {children}
       </body>
     </html>
   );

--- a/frontend/src/app/page.tsx
+++ b/frontend/src/app/page.tsx
@@ -1,9 +1,5 @@
-import MapView from "@/components/MapView";
+import { redirect } from "next/navigation";
 
 export default function Home() {
-  return (
-    <div className="h-full w-full bg-zinc-50 font-sans dark:bg-black">
-      <MapView />
-    </div>
-  );
+  redirect("/login");
 }

--- a/frontend/src/components/navigation/BottomNav.tsx
+++ b/frontend/src/components/navigation/BottomNav.tsx
@@ -12,7 +12,7 @@ const tabs: {
   label: string;
   href: string;
 }[] = [
-  { id: "map", icon: Map, label: "Map", href: "/" },
+  { id: "map", icon: Map, label: "Map", href: "/map" },
   { id: "feed", icon: LayoutGrid, label: "Feed", href: "/feed" },
   { id: "events", icon: Calendar, label: "Events", href: "/events" },
   { id: "profile", icon: User, label: "Profile", href: "/profile" },
@@ -24,7 +24,7 @@ export default function BottomNav() {
   return (
     <div className="fixed bottom-0 left-0 right-0 h-20 bg-[#0a0a0f]/90 backdrop-blur-xl border-t border-white/10 flex items-center justify-around px-4 z-40 md:hidden">
       {tabs.map((tab) => {
-        const isActive = pathname === tab.href || (tab.id === "map" && pathname === "/");
+        const isActive = pathname === tab.href;
         return (
           <Link href={tab.href} key={tab.id} className="flex-1 flex justify-center">
             <Button

--- a/frontend/src/components/navigation/DesktopSidebar.tsx
+++ b/frontend/src/components/navigation/DesktopSidebar.tsx
@@ -12,7 +12,7 @@ const tabs: {
   label: string;
   href: string;
 }[] = [
-  { id: "map", icon: Map, label: "Map", href: "/" },
+  { id: "map", icon: Map, label: "Map", href: "/map" },
   { id: "feed", icon: LayoutGrid, label: "Feed", href: "/feed" },
   { id: "events", icon: Calendar, label: "Events", href: "/events" },
   { id: "profile", icon: User, label: "Profile", href: "/profile" },
@@ -25,7 +25,7 @@ export default function DesktopSidebar() {
     <div className="fixed left-0 top-0 bottom-0 w-16 bg-[#0a0a0f]/90 backdrop-blur-xl border-r border-white/10 flex flex-col items-center py-6 z-40">
       <div className="flex flex-col gap-2">
         {tabs.map((tab) => {
-          const isActive = pathname === tab.href || (tab.id === "map" && pathname === "/");
+          const isActive = pathname === tab.href;
           return (
             <Link href={tab.href} key={tab.id}>
               <Button

--- a/frontend/src/middleware.ts
+++ b/frontend/src/middleware.ts
@@ -1,0 +1,12 @@
+import { NextRequest, NextResponse } from "next/server";
+
+export function middleware(request: NextRequest) {
+  const token = request.cookies.get("access_token");
+  const isLoginPage = request.nextUrl.pathname === "/login";
+  
+  if (token && isLoginPage) {
+    return NextResponse.redirect(new URL("/map", request.url));
+  }
+
+  return NextResponse.next();
+}


### PR DESCRIPTION
- Add login page to frontend
- Use route groups to use different layout for login page
- Fix path names for map in navigation
- Use middleware to block using /login page and redirect to map. 

Middleware should be removed later if we want to allow redirecting to login page if the user is already logged in and show log out button on the login page.

Redirect uri in google cloud console /signin-google