### PR TITLE
Post-Place relation

### DIFF
--- a/DomainLayer/Entities/Post.cs
+++ b/DomainLayer/Entities/Post.cs
@@ -20,10 +20,10 @@ namespace DomainLayer.Entities
         //public Guid AuthorId { get; set; }
         //public User Author { get; set; }
 
-        //[Required]
-        //[ForeignKey(nameof(Place))]
-        //public Guid PlaceId { get; set; }
-        //public Place Place { get; set; }
+        [Required]
+        [ForeignKey(nameof(Place))]
+        public Guid PlaceId { get; set; }
+        public Place Place { get; set; }
 
         //[Required]
         //[ForeignKey(nameof(Image))]

--- a/SportMap.AL/DTOs/PostDTO.cs
+++ b/SportMap.AL/DTOs/PostDTO.cs
@@ -7,17 +7,21 @@ namespace SportMap.AL.DTOs
     {
         public PostDTO() { }
 
-        public PostDTO(Guid id, string title, string content, StatusType status)
+        public PostDTO(Guid id, string title, string content, StatusType status, Guid placeId, DateTime createdAt)
         {
             Id = id;
             Title = title;
             Content = content;
             Status = status;
+            PlaceId = placeId;
+            CreatedAt = createdAt;
         }
 
         public Guid Id { get; set; }
         public string Title { get; set; }
         public string Content { get; set; }
         public StatusType Status { get; set; }
+        public Guid PlaceId { get; set; }
+        public DateTime CreatedAt { get; set; }
     }
 }

--- a/SportMap.AL/Extensions/DIInitializationExtensions.cs
+++ b/SportMap.AL/Extensions/DIInitializationExtensions.cs
@@ -22,6 +22,7 @@ namespace SportMap.Al.Extensions
             // Posts
             serviceCollection.AddTransient<GetPostQueryHandler>();
             serviceCollection.AddTransient<CreatePostCommandHandler>();
+            serviceCollection.AddTransient<GetLatestUpdateQueryHandler>();
 
             // Images
             serviceCollection.AddTransient<GetImageQueryHandler>();

--- a/SportMap.AL/UseCases/Feeds/CreatePostCommandHandler.cs
+++ b/SportMap.AL/UseCases/Feeds/CreatePostCommandHandler.cs
@@ -11,7 +11,7 @@ namespace SportMap.AL.UseCases.Feeds
     {
         public async Task<Result<PostDTO>> Handle(CreatePostCommand command, CancellationToken cancellationToken)
         {
-            var post = new PostDTO(Guid.NewGuid(), command.Title, command.Content, StatusType.Pending);
+            var post = new PostDTO(Guid.NewGuid(), command.Title, command.Content, StatusType.Verified, command.PlaceId, DateTime.UtcNow);
             
             try
             {
@@ -36,5 +36,5 @@ namespace SportMap.AL.UseCases.Feeds
     }
 
     public record CreatePostCommand(string Content, 
-        string Title) : ICommand<PostDTO>;
+        string Title, Guid PlaceId) : ICommand<PostDTO>;
 }

--- a/SportMap.AL/UseCases/Feeds/FeedsExtensions.cs
+++ b/SportMap.AL/UseCases/Feeds/FeedsExtensions.cs
@@ -14,7 +14,9 @@ namespace SportMap.AL.UseCases.Feeds
                     Content = data.Content,
                     Id = data.Id,
                     Title = data.Title,
-                    Status = data.Status
+                    Status = data.Status,
+                    PlaceId = data.PlaceId,
+                    CreatedAt = data.CreatedAt
                 };
             }
         }
@@ -28,7 +30,9 @@ namespace SportMap.AL.UseCases.Feeds
                     Id = dto.Id,
                     Content = dto.Content,
                     Status = dto.Status,
-                    Title = dto.Title
+                    Title = dto.Title,
+                    PlaceId = dto.PlaceId,
+                    CreatedAt = dto.CreatedAt
                 };
             }
         }

--- a/SportMap.AL/UseCases/Feeds/GetLatestUpdateQueryHandler.cs
+++ b/SportMap.AL/UseCases/Feeds/GetLatestUpdateQueryHandler.cs
@@ -1,0 +1,43 @@
+using DomainLayer.Entities.Enums;
+using Microsoft.Extensions.Logging;
+using SportMap.AL.Abstractions.UseCases;
+using SportMap.DAL.Abstractions;
+
+namespace SportMap.AL.UseCases.Feeds
+{
+    public class GetLatestUpdateQueryHandler(IUnitOfWork unitOfWork, ILogger<GetLatestUpdateQueryHandler> logger) : IQueryHandler<GetLatestUpdateQuery, DateTime?>
+    {
+        public async Task<Result<DateTime?>> Handle(GetLatestUpdateQuery query, CancellationToken cancellationToken)
+        {
+            logger.LogInformation("{className}.{methodName}: Trying to retrieve latest update for place {placeId}", nameof(GetLatestUpdateQueryHandler), nameof(Handle), query.PlaceId);
+
+            try
+            {
+                var posts = await unitOfWork.PostRepository.FindAsync(p => p.PlaceId == query.PlaceId && p.Status == StatusType.Verified, cancellationToken);
+                
+                if (posts.Count == 0)
+                {
+                    return Result<DateTime?>.WithData(null);
+                }
+
+                var latestUpdate = posts
+                    .Select(p => p.ModifiedAt ?? p.CreatedAt)
+                    .Max();
+
+                return Result<DateTime?>.WithData(latestUpdate);
+            }
+            catch (OperationCanceledException oce) when (cancellationToken.IsCancellationRequested)
+            {
+                logger.LogWarning(oce, "{class}.{method}: Operation was canceled.", nameof(GetLatestUpdateQueryHandler), nameof(Handle));
+                return Result<DateTime?>.WithError("Operation was canceled.");
+            }
+            catch (Exception e)
+            {
+                logger.LogError(e, "{class}.{method}: Unhandled exception {message}", nameof(GetLatestUpdateQueryHandler), nameof(Handle), e.Message);
+                return Result<DateTime?>.WithError(e.Message);
+            }
+        }
+    }
+
+    public record GetLatestUpdateQuery(Guid PlaceId) : IQuery<DateTime?>;
+}

--- a/SportMap.AL/UseCases/Feeds/GetPostQueryHandler.cs
+++ b/SportMap.AL/UseCases/Feeds/GetPostQueryHandler.cs
@@ -28,7 +28,9 @@ namespace SportMap.AL.UseCases.Feeds
                 var postData= await unitOfWork.PostRepository.GetAllAsync(cancellationToken);
                 var filteredPosts = postData
                     .Where(post => post.Status.Equals(query.Status))
-                    .FilterIfNotNull(query.Id, (post, id) => post.Id == id);
+                    .FilterIfNotNull(query.Id, (post, id) => post.Id == id)
+                    .FilterIfNotNull(query.PlaceId, (post, placeId) => post.PlaceId == placeId)
+                    .OrderByDescending(post => post.CreatedAt);
 
                 posts = filteredPosts
                     .Select(post => post.Map())
@@ -50,5 +52,5 @@ namespace SportMap.AL.UseCases.Feeds
         }
     }
 
-    public record GetPostQuery(Guid? Id, StatusType Status) : IQuery<IReadOnlyList<PostDTO>>;
+    public record GetPostQuery(Guid? Id, StatusType Status, Guid? PlaceId = null) : IQuery<IReadOnlyList<PostDTO>>;
 }

--- a/SportMap.DAL/Migrations/20260413100036_AddPlaceIdToPosts.Designer.cs
+++ b/SportMap.DAL/Migrations/20260413100036_AddPlaceIdToPosts.Designer.cs
@@ -2,6 +2,7 @@
 using System;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 using SportMap.DAL.DataContext;
@@ -11,9 +12,11 @@ using SportMap.DAL.DataContext;
 namespace SportMap.DAL.Migrations
 {
     [DbContext(typeof(AppDbContext))]
-    partial class AppDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260413100036_AddPlaceIdToPosts")]
+    partial class AddPlaceIdToPosts
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/SportMap.DAL/Migrations/20260413100036_AddPlaceIdToPosts.cs
+++ b/SportMap.DAL/Migrations/20260413100036_AddPlaceIdToPosts.cs
@@ -1,0 +1,51 @@
+﻿using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace SportMap.DAL.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddPlaceIdToPosts : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<Guid>(
+                name: "PlaceId",
+                table: "Posts",
+                type: "uuid",
+                nullable: false,
+                defaultValue: new Guid("00000000-0000-0000-0000-000000000000"));
+
+            migrationBuilder.CreateIndex(
+                name: "IX_Posts_PlaceId",
+                table: "Posts",
+                column: "PlaceId");
+
+            migrationBuilder.AddForeignKey(
+                name: "FK_Posts_Places_PlaceId",
+                table: "Posts",
+                column: "PlaceId",
+                principalTable: "Places",
+                principalColumn: "Id",
+                onDelete: ReferentialAction.Cascade);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropForeignKey(
+                name: "FK_Posts_Places_PlaceId",
+                table: "Posts");
+
+            migrationBuilder.DropIndex(
+                name: "IX_Posts_PlaceId",
+                table: "Posts");
+
+            migrationBuilder.DropColumn(
+                name: "PlaceId",
+                table: "Posts");
+        }
+    }
+}

--- a/SportMap.Server/Controllers/FeedController.cs
+++ b/SportMap.Server/Controllers/FeedController.cs
@@ -14,17 +14,18 @@ namespace SportMap.PL.Controllers
     public class FeedController(
         GetPostQueryHandler getPosts,
         CreatePostCommandHandler createPosts,
+        GetLatestUpdateQueryHandler getLatestUpdate,
         ILogger<FeedController> logger) : BaseController<PostDTO>(logger)
     {
         // GET: api/feed
         [HttpGet]
-        public async Task<Results<InternalServerError, NotFound, Ok<IReadOnlyList<PostDTO>>>> Get()
+        public async Task<Results<InternalServerError, NotFound, Ok<IReadOnlyList<PostDTO>>>> Get([FromQuery] Guid? placeId)
         {
             AL.Abstractions.UseCases.Result<IReadOnlyList<PostDTO>>? result;
 
             try
             {
-                var query = new GetPostQuery(null, StatusType.Verified);
+                var query = new GetPostQuery(null, StatusType.Verified, placeId);
                 result = await getPosts.Handle(query, CancellationToken.None);
             }
             catch (Exception e)
@@ -58,7 +59,7 @@ namespace SportMap.PL.Controllers
 
             try
             {
-                var query = new GetPostQuery(null, StatusType.Verified);
+                var query = new GetPostQuery(id, StatusType.Verified);
                 result = await getPosts.Handle(query, CancellationToken.None);
             }
             catch (Exception e)
@@ -84,19 +85,43 @@ namespace SportMap.PL.Controllers
             return TypedResults.Ok(posts[0]);
         }
 
+        // GET: api/feed/latest-update
+        [HttpGet("latest-update")]
+        public async Task<Results<InternalServerError, Ok<DateTime?>>> GetLatestUpdate([FromQuery] Guid placeId)
+        {
+            try
+            {
+                var query = new GetLatestUpdateQuery(placeId);
+                var result = await getLatestUpdate.Handle(query, CancellationToken.None);
+
+                if (result.HasError)
+                {
+                    _logger.LogError("{controllerName}.{methodName}: Error occurred while fetching latest update: {ErrorMessage}", nameof(FeedController), nameof(GetLatestUpdate), result.ErrorMessage);
+                    return TypedResults.InternalServerError();
+                }
+
+                return TypedResults.Ok(result.Data);
+            }
+            catch (Exception e)
+            {
+                _logger.LogError(e, "{className}.{methodName}: Unhandled exception occured: {message}", nameof(FeedController), nameof(GetLatestUpdate), e.Message);
+                return TypedResults.InternalServerError();
+            }
+        }
+
         // POST: api/feed
         [HttpPost]
         [AllowAnonymous]
         public async Task<Results<InternalServerError, BadRequest, CreatedAtRoute<PostDTO>>> CreatePost([FromBody] CreatePostRequest request)
         {
-            if (request.Title.IsNullOrEmpty() || request.Content.IsNullOrEmpty())
+            if (request.Title.IsNullOrEmpty() || request.Content.IsNullOrEmpty() || request.PlaceId == Guid.Empty)
             {
-                _logger.LogWarning("Title or content is null or empty");
+                _logger.LogWarning("Title, content or placeId is null, empty or default");
 
                 return TypedResults.BadRequest();
             }
 
-            var command = new CreatePostCommand(request.Title, request.Content);
+            var command = new CreatePostCommand(request.Title, request.Content, request.PlaceId);
             var result = await createPosts.Handle(command, CancellationToken.None);
 
             if (result.HasError)
@@ -108,9 +133,10 @@ namespace SportMap.PL.Controllers
         }
     }
 
-    public class CreatePostRequest(string title, string content)
+    public class CreatePostRequest(string title, string content, Guid placeId)
     {
         public string Title { get; init; } = title;
         public string Content { get; init; } = content;
+        public Guid PlaceId { get; init; } = placeId;
     }
 }

--- a/frontend/src/app/(app)/map/page.tsx
+++ b/frontend/src/app/(app)/map/page.tsx
@@ -1,10 +1,12 @@
 'use client';
 
-import { useState, useEffect, useCallback } from 'react';
+import { useState, useEffect, useCallback, Suspense } from 'react';
 import dynamic from 'next/dynamic';
+import { useSearchParams } from 'next/navigation';
 import PlaceList from '@/components/PlaceList';
-import { placeService, type PlaceDto } from '@/services/place.service';
-import { placeTypeService, type PlaceTypeDto } from '@/services/place-type.service';
+import { placeService } from '@/services/place.service';
+import { placeTypeService } from '@/services/place-type.service';
+import type { PlaceDto, PlaceTypeDto } from '@/types/place';
 import SearchBar from '@/components/SearchBar';
 
 // Dynamic import for MapView to avoid SSR issues
@@ -13,7 +15,10 @@ const MapView = dynamic(() => import('@/components/MapView'), {
   loading: () => <div className="w-full h-full bg-zinc-100 dark:bg-zinc-900 animate-pulse" />
 });
 
-export default function MapPage() {
+function MapContent() {
+  const searchParams = useSearchParams();
+  const placeIdFromUrl = searchParams.get('placeId');
+  
   const [view, setView] = useState<'map' | 'list'>('map');
   const [places, setPlaces] = useState<PlaceDto[]>([]);
   const [placeTypes, setPlaceTypes] = useState<PlaceTypeDto[]>([]);
@@ -21,6 +26,8 @@ export default function MapPage() {
   const [selectedPlace, setSelectedPlace] = useState<PlaceDto | null>(null);
   const [loading, setLoading] = useState(true);
   const [isRefreshing, setIsRefreshing] = useState(false);
+  const [hasProcessedUrlParam, setHasProcessedUrlParam] = useState(false);
+
   // Fetch place types
   useEffect(() => {
     async function fetchPlaceTypes() {
@@ -55,6 +62,37 @@ export default function MapPage() {
   useEffect(() => {
     fetchPlaces();
   }, [fetchPlaces]);
+
+  // Handle placeId from URL
+  useEffect(() => {
+    if (placeIdFromUrl && !hasProcessedUrlParam) {
+      const handleUrlParam = async () => {
+        // If places are still loading, wait or fetch specifically
+        // If not in currently loaded places (might be filtered out), fetch by ID
+        const existing = places.find(p => p.id === placeIdFromUrl);
+        if (existing) {
+          setSelectedPlace(existing);
+          setSelectedPlaceTypeId(null); // Clear filter to show the place
+          setView('map');
+          setHasProcessedUrlParam(true);
+        } else if (!loading) {
+          // If not loading and not found, fetch specifically
+          const result = await placeService.getById(placeIdFromUrl);
+          if (result.isSucceed && result.value) {
+            setPlaces(prev => {
+              if (prev.some(p => p.id === result.value!.id)) return prev;
+              return [...prev, result.value!];
+            });
+            setSelectedPlace(result.value);
+            setSelectedPlaceTypeId(null);
+            setView('map');
+          }
+          setHasProcessedUrlParam(true);
+        }
+      };
+      handleUrlParam();
+    }
+  }, [placeIdFromUrl, places, loading, hasProcessedUrlParam]);
 
   const handleSearchPlaceSelect = (place: PlaceDto) => {
     setSelectedPlace(place);
@@ -140,5 +178,13 @@ export default function MapPage() {
         )}
       </div>
     </div>
+  );
+}
+
+export default function MapPage() {
+  return (
+    <Suspense fallback={<div className="h-full w-full bg-zinc-50 dark:bg-black animate-pulse" />}>
+      <MapContent />
+    </Suspense>
   );
 }

--- a/frontend/src/components/PlaceDetailSheet.tsx
+++ b/frontend/src/components/PlaceDetailSheet.tsx
@@ -1,43 +1,13 @@
-import React from 'react';
+import { useState, useEffect } from 'react';
 import { motion, AnimatePresence } from 'framer-motion';
-import { X, MapPin, Star, Flag, Trophy, ExternalLink } from 'lucide-react';
-
-export interface PlaceType {
-  id: string;
-  name: string;
-  description: string;
-}
-
-export interface Image {
-  id: string;
-  name: string;
-  url: string;
-  entityId: string;
-}
-
-export interface Place {
-  id: string;
-  name: string;
-  placeTypeId: string;
-  placeType?: PlaceType;
-  location: { lat: number; lng: number };
-  address?: string;
-  description?: string;
-  imageId: string;
-  image?: Image;
-  creatorId: string;
-  createdAt: string;
-  updatedAt: string;
-  status: string;
-  reviewerId?: string;
-  // UI-specific fields (calculated/not in DB)
-  distance?: string;
-  rating?: number;
-  tags?: string[];
-}
+import { X, MapPin, Flag, MessageSquare, Clock } from 'lucide-react';
+import { formatRelativeTime } from '@/lib/date-utils';
+import { feedService } from '@/services/feed.service';
+import type { PostDto } from '@/types/post';
+import type { PlaceDto } from '@/types/place';
 
 interface PlaceDetailSheetProps {
-  place: Place | null;
+  place: PlaceDto | null;
   onClose: () => void;
   onReport: () => void;
 }
@@ -47,6 +17,57 @@ export default function PlaceDetailSheet({
   onClose,
   onReport
 }: PlaceDetailSheetProps) {
+  const [posts, setPosts] = useState<PostDto[]>([]);
+  const [isLoadingPosts, setIsLoadingPosts] = useState(false);
+  const [lastUpdate, setLastUpdate] = useState<string | null>(null);
+
+  // Initial fetch
+  useEffect(() => {
+    if (place?.id) {
+      setIsLoadingPosts(true);
+      
+      const loadData = async () => {
+        const [postsResult, latestUpdateResult] = await Promise.all([
+          feedService.getByPlaceId(place.id!),
+          feedService.getLatestUpdate(place.id!)
+        ]);
+        
+        if (postsResult.value) {
+          setPosts(postsResult.value);
+        }
+        if (latestUpdateResult.value) {
+          setLastUpdate(latestUpdateResult.value);
+        }
+        setIsLoadingPosts(false);
+      };
+
+      loadData();
+    } else {
+      setPosts([]);
+      setLastUpdate(null);
+    }
+  }, [place?.id]);
+
+  // Polling for updates
+  useEffect(() => {
+    if (!place?.id) return;
+
+    const pollInterval = setInterval(async () => {
+      const result = await feedService.getLatestUpdate(place.id!);
+      
+      // Only refresh posts if the latest update timestamp changed
+      if (result.value && result.value !== lastUpdate) {
+        const postsResult = await feedService.getByPlaceId(place.id!);
+        if (postsResult.value) {
+          setPosts(postsResult.value);
+          setLastUpdate(result.value);
+        }
+      }
+    }, 10000); // Poll every 10 seconds
+
+    return () => clearInterval(pollInterval);
+  }, [place?.id, lastUpdate]);
+
   if (!place) return null;
 
   // Get image URL - prioritize place.image.url, fallback to a default
@@ -115,38 +136,16 @@ export default function PlaceDetailSheet({
                   <div className="flex items-center text-gray-400 text-sm mb-2">
                     <MapPin size={14} className="mr-1 text-blue-400" />
                     <span>
-                      {place.distance} •{' '}
                       {place.address || 'Tallinn, Estonia'}
                     </span>
                   </div>
                   <div className="flex flex-wrap gap-2">
-                    {place.tags?.map((tag) => (
-                      <span
-                        key={tag}
-                        className="px-2 py-0.5 rounded-md bg-white/5 border border-white/5 text-xs text-gray-300"
-                      >
-                        {tag}
-                      </span>
-                    )) || (
+                    {place.placeType && (
                       <span className="px-2 py-0.5 rounded-md bg-white/5 border border-white/5 text-xs text-gray-300">
-                        {place.placeType?.name || 'Unknown'}
+                        {place.placeType.name}
                       </span>
                     )}
                   </div>
-                </div>
-                <div className="flex flex-col items-end space-y-2">
-                  <div className="flex items-center bg-yellow-500/10 px-2 py-1 rounded-lg border border-yellow-500/20">
-                    <Star
-                      size={14}
-                      className="text-yellow-500 mr-1 fill-yellow-500"
-                    />
-                    <span className="text-yellow-500 font-bold text-sm">
-                      {place.rating || 'N/A'}
-                    </span>
-                  </div>
-                  <button className="flex items-center text-blue-400 text-xs font-medium hover:text-blue-300 transition-colors">
-                    Get Directions <ExternalLink size={10} className="ml-1" />
-                  </button>
                 </div>
               </div>
 
@@ -157,55 +156,14 @@ export default function PlaceDetailSheet({
               </p>
 
               {/* Actions Grid */}
-              <div className="grid grid-cols-2 gap-3 mb-8">
-                <button className="py-3 rounded-xl bg-gradient-to-r from-blue-600 to-cyan-500 text-white font-bold text-sm shadow-[0_0_20px_rgba(59,130,246,0.4)] hover:shadow-[0_0_30px_rgba(59,130,246,0.6)] transition-all active:scale-[0.98]">
+              <div className="flex gap-3 mb-8">
+                <button className="flex-1 py-3 rounded-xl bg-gradient-to-r from-blue-600 to-cyan-500 text-white font-bold text-sm shadow-[0_0_20px_rgba(59,130,246,0.4)] hover:shadow-[0_0_30px_rgba(59,130,246,0.6)] transition-all active:scale-[0.98]">
                   Check In Now
                 </button>
-                <button className="py-3 rounded-xl bg-[#12121a] border border-white/10 text-white font-semibold text-sm hover:bg-white/5 transition-colors">
-                  Add to Favorites
-                </button>
-              </div>
-
-              {/* Active Challenges */}
-              <div className="mb-8">
-                <h3 className="text-sm font-semibold text-gray-400 uppercase tracking-wider mb-3 flex items-center justify-between">
-                  Active Challenges
-                  <span className="text-blue-400 text-xs cursor-pointer">
-                    View All
-                  </span>
-                </h3>
-                <div className="space-y-3">
-                  {[1, 2].map((i) => (
-                    <div
-                      key={i}
-                      className="bg-white/5 p-3 rounded-xl border border-white/5 flex items-center hover:bg-white/10 transition-colors cursor-pointer"
-                    >
-                      <div className="w-10 h-10 rounded-full bg-blue-500/20 flex items-center justify-center mr-3 text-blue-400">
-                        <Trophy size={18} />
-                      </div>
-                      <div className="flex-1">
-                        <p className="text-white font-medium text-sm">
-                          Morning Sprint {i}
-                        </p>
-                        <p className="text-gray-500 text-xs">
-                          24 participants • Ends in 2h
-                        </p>
-                      </div>
-                      <button className="px-3 py-1 rounded-full bg-blue-500/20 text-blue-400 text-xs font-bold">
-                        Join
-                      </button>
-                    </div>
-                  ))}
-                </div>
-              </div>
-
-              {/* Upcoming Events placeholder */}
-              <div className="mb-8">
-                <h3 className="text-sm font-semibold text-gray-400 uppercase tracking-wider mb-3">
-                  Upcoming Events
-                </h3>
-                <div className="text-gray-500 text-sm">
-                  No upcoming events at this location.
+                <div className="flex-1 flex gap-2">
+                  <button className="flex-1 py-3 rounded-xl bg-[#12121a] border border-white/10 text-white font-semibold text-sm hover:bg-white/5 transition-colors">
+                    Add to Favorites
+                  </button>
                 </div>
               </div>
 
@@ -214,12 +172,43 @@ export default function PlaceDetailSheet({
                 <h3 className="text-sm font-semibold text-gray-400 uppercase tracking-wider mb-3">
                   Recent Activity
                 </h3>
-                <div className="text-gray-500 text-sm">
-                  No recent activity at this location.
-                </div>
+                {isLoadingPosts ? (
+                  <div className="flex justify-center py-4">
+                    <div className="w-6 h-6 border-2 border-blue-500 border-t-transparent rounded-full animate-spin" />
+                  </div>
+                ) : posts.length > 0 ? (
+                  <div className="space-y-4">
+                    {posts.map((post) => (
+                      <div key={post.id} className="bg-white/5 p-4 rounded-xl border border-white/5">
+                        <div className="flex items-center mb-2">
+                          <div className="w-8 h-8 rounded-full bg-gradient-to-br from-blue-500 to-cyan-400 flex items-center justify-center text-white text-xs font-bold mr-3">
+                            {post.title.charAt(0).toUpperCase()}
+                          </div>
+                          <div>
+                            <p className="text-white font-medium text-sm">{post.title}</p>
+                            <div className="flex items-center text-gray-500 text-xs">
+                              <Clock size={10} className="mr-1" />
+                              <span>{formatRelativeTime(post.createdAt)}</span>
+                            </div>
+                          </div>
+                        </div>
+                        <p className="text-gray-300 text-sm">{post.content}</p>
+                        <div className="mt-3 flex items-center text-gray-500 text-xs">
+                          <MessageSquare size={12} className="mr-1" />
+                          <span>Reply</span>
+                        </div>
+                      </div>
+                    ))}
+                  </div>
+                ) : (
+                  <div className="text-gray-500 text-sm">
+                    No recent activity at this location.
+                  </div>
+                )}
               </div>
             </div>
         </motion.div>
+
       </>
     </AnimatePresence>
   );

--- a/frontend/src/lib/date-utils.ts
+++ b/frontend/src/lib/date-utils.ts
@@ -1,0 +1,26 @@
+export function formatRelativeTime(dateString: string): string {
+  const date = new Date(dateString);
+  const now = new Date();
+  const diffInSeconds = Math.floor((now.getTime() - date.getTime()) / 1000);
+
+  if (diffInSeconds < 60) {
+    return 'just now';
+  }
+
+  const diffInMinutes = Math.floor(diffInSeconds / 60);
+  if (diffInMinutes < 60) {
+    return `${diffInMinutes}m ago`;
+  }
+
+  const diffInHours = Math.floor(diffInMinutes / 60);
+  if (diffInHours < 24) {
+    return `${diffInHours}h ago`;
+  }
+
+  const diffInDays = Math.floor(diffInHours / 24);
+  if (diffInDays < 7) {
+    return `${diffInDays}d ago`;
+  }
+
+  return date.toLocaleDateString();
+}

--- a/frontend/src/services/feed.service.ts
+++ b/frontend/src/services/feed.service.ts
@@ -1,0 +1,48 @@
+import { BaseService } from './base.service';
+import type { PostDto } from '@/types/post';
+import { ResultOf } from '@/lib/result';
+
+export class FeedService extends BaseService<PostDto> {
+  protected readonly endpoint = 'feed';
+
+  constructor() {
+    const baseUrl = process.env.NEXT_PUBLIC_API_URL;
+    super(baseUrl);
+  }
+
+  async getByPlaceId(placeId: string): Promise<ResultOf<PostDto[]>> {
+    try {
+      const url = `${this.url}?placeId=${placeId}`;
+      const response = await fetch(url);
+      
+      if (response.status === 404) {
+        return ResultOf.withValue([]);
+      }
+
+      if (!response.ok) throw new Error(`HTTP error: ${response.status}`);
+      
+      return ResultOf.withValue((await response.json()) as PostDto[]);
+    } catch (error) {
+      return ResultOf.withError<PostDto[]>(
+        error instanceof Error ? error : new Error(String(error))
+      );
+    }
+  }
+
+  async getLatestUpdate(placeId: string): Promise<ResultOf<string | null>> {
+    try {
+      const url = `${this.url}/latest-update?placeId=${placeId}`;
+      const response = await fetch(url);
+
+      if (!response.ok) throw new Error(`HTTP error: ${response.status}`);
+
+      return ResultOf.withValue(await response.json());
+    } catch (error) {
+      return ResultOf.withError<string | null>(
+        error instanceof Error ? error : new Error(String(error))
+      );
+    }
+  }
+}
+
+export const feedService = new FeedService();

--- a/frontend/src/types/post.ts
+++ b/frontend/src/types/post.ts
@@ -1,0 +1,8 @@
+import { BaseData } from './base';
+
+export interface PostDto extends BaseData {
+  title: string;
+  content: string;
+  status: string;
+  placeId: string;
+}


### PR DESCRIPTION
Establishes a many-to-one relationship between Posts and Places. It allows users to see "Recent Activity" posts associated with a specific location directly in the place details view.

Backend:
   • Database migration: Added PlaceId foreign key to the Posts table.
   • Application Layer:
     • Updated GetPostQuery and its handler to support filtering by PlaceId.
     • Implemented GetLatestUpdateQuery to fetch the timestamp of the most recent post for a place, enabling efficient frontend polling.
     • Updated CreatePostCommand to require a PlaceId.

API:
     • Updated FeedController to allow filtering the feed by placeId.
     • Added GET /api/feed/latest-update endpoint for polling.

Frontend:
   • Types and services:
     • Updated PostDto to include placeId.
     • Updated FeedService with getByPlaceId and getLatestUpdate methods.
   • UI:
     • Wired PlaceDetailSheet "Recent Activity" section.
     • Implemented a polling mechanism every 10 seconds that refreshes the place-specific feed only when new activity is detected via the latest-update endpoint.